### PR TITLE
Minor tweak to hostname check for Cygwin environment support

### DIFF
--- a/tarsnap-generations.sh
+++ b/tarsnap-generations.sh
@@ -109,19 +109,26 @@ else
         fi
 fi
 
+#Determine the hostname of the system
+if [[ `uname -s` != CYGWIN* ]]; then
+    HOSTNAME=`hostname -s`
+else
+    HOSTNAME=`hostname`
+fi
+
 #Take the backup with the right name 
 if [ $QUIET != "1" ] ; then
     echo "Starting $BK_TYPE backups..."
 fi
 
 for dir in $(cat $PATHS) ; do
-	tarsnap -c -f $NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) --one-file-system -C / $dir
+	tarsnap -c -f $NOW-$BK_TYPE-$HOSTNAME-$(echo $dir) --one-file-system -C / $dir
 	if [ $? = 0 ] ; then
 	    if [ $QUIET != "1" ] ; then
-		echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) backup done."
+		echo "$NOW-$BK_TYPE-$HOSTNAME-$(echo $dir) backup done."
 	    fi
 	else
-		echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) backup error. Exiting" ; exit $?
+		echo "$NOW-$BK_TYPE-$HOSTNAME-$(echo $dir) backup error. Exiting" ; exit $?
 	fi
 done	
 
@@ -134,11 +141,11 @@ archive_list=$(tarsnap --list-archives)
 
 for dir in $(cat $PATHS) ; do
 	case "$archive_list" in
-		*"$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir)"* )
+		*"$NOW-$BK_TYPE-$HOSTNAME-$(echo $dir)"* )
 		if [ $QUIET != "1" ] ; then
-		    echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) backup OK."
+		    echo "$NOW-$BK_TYPE-$HOSTNAME-$(echo $dir) backup OK."
 		fi ;;
-		* ) echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) backup NOT OK. Check --archive-list."; exit 3 ;; 
+		* ) echo "$NOW-$BK_TYPE-$HOSTNAME-$(echo $dir) backup NOT OK. Check --archive-list."; exit 3 ;; 
 	esac
 done
 


### PR DESCRIPTION
I'm pleased to say your script works perfectly on Cygwin except for the
hostname check. Under Cygwin the hostname command has no parameters and
so the "-s" option fails. However, it returns a short name by default.

Some Cygwin environments may also run into a problem due to the "cal"
program not being included, however, this can easily be fixed via
installing the util-linux package.
