### PR TITLE
Improve method of determining the last day of the month.

### DIFF
--- a/tarsnap-generations.sh
+++ b/tarsnap-generations.sh
@@ -85,8 +85,8 @@ fi
 DOW=$($DATE_BIN +%u)
 #The calendar day of the month
 DOM=$($DATE_BIN +%d)
-#The last day of the current month. I wish there was a better way to do this, but this seems to work everywhere. 
-LDOM=$(echo $(cal) | awk '{print $NF}')
+#The last day of the current month
+LDOM=$(date -d "$(date +%y-%m-01) +1 month -1 day" +%d)
 #We need 'NOW' to be constant during execution, we set it here.
 NOW=$($DATE_BIN +%Y%m%d-%H)
 CUR_HOUR=$($DATE_BIN +%H)


### PR DESCRIPTION
As per the Git commit, this is a particularly important bugfix as the current method will break the creation of MONTHLY backups on systems where the cal binary defaults to output where the current day is highlighted. The net effect of this is that MONTHLY backups will never be created and the DAILY backups that are created instead will never be cleaned up. Depending on how long it takes the user to notice, this can result in a significant accumulation of "useless" backups that are costing money in storage space on the AWS S3 backend.
