### PR TITLE
Friendlier archive names, tarsnap errors

### DIFF
--- a/tarsnap-generations.sh
+++ b/tarsnap-generations.sh
@@ -115,13 +115,14 @@ if [ $QUIET != "1" ] ; then
 fi
 
 for dir in $(cat $PATHS) ; do
-	tarsnap -c -f $NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) --one-file-system -C / $dir
+	tarsnap -c -f $NOW-$BK_TYPE-$(hostname -s)-$(echo ${dir//\//.}) --one-file-system -C / $dir
 	if [ $? = 0 ] ; then
 	    if [ $QUIET != "1" ] ; then
-		echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) backup done."
+		echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo ${dir//\//.}) backup done."
 	    fi
 	else
-		echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) backup error. Exiting" ; exit $?
+		errcode=$?
+		echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo ${dir//\//.}) backup error. Exiting" ; exit $errcode
 	fi
 done	
 
@@ -134,11 +135,11 @@ archive_list=$(tarsnap --list-archives)
 
 for dir in $(cat $PATHS) ; do
 	case "$archive_list" in
-		*"$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir)"* )
+		*"$NOW-$BK_TYPE-$(hostname -s)-$(echo ${dir//\//.})"* )
 		if [ $QUIET != "1" ] ; then
-		    echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) backup OK."
+		    echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo ${dir//\//.}) backup OK."
 		fi ;;
-		* ) echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) backup NOT OK. Check --archive-list."; exit 3 ;; 
+		* ) echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo ${dir//\//.}) backup NOT OK. Check --archive-list."; exit 3 ;; 
 	esac
 done
 


### PR DESCRIPTION
1) When using paths like /path/to/my/folder inside tarsnap.folders, tarsnap-generations will use that as $dir in the filename, which can cause issues because of slashes. Proposed method is to replace slashes with dots to keep filenames harmless.

2)Line 124, the exit $? exits with the status of the last echo, which is always 0. Better to store tarsnap's code in an $errcode variable and use it in the exit statement.
