### PR TITLE
Update tarsnap-generations.sh

### DIFF
--- a/tarsnap-generations.sh
+++ b/tarsnap-generations.sh
@@ -11,6 +11,8 @@ DAILY_TIME=23										#
 USE_UTC=0										#
 #Path to GNU date binary (e.g. /bin/date on Linux, /usr/local/bin/gdate on FreeBSD)	#
 DATE_BIN=`which date`									#
+#Path to Tarsnap binary									#
+TARSNAP_BIN=`which tarsnap`								#
 #########################################################################################
 usage ()
 {
@@ -115,7 +117,7 @@ if [ $QUIET != "1" ] ; then
 fi
 
 for dir in $(cat $PATHS) ; do
-	tarsnap -c -f $NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) --one-file-system -C / $dir
+	$TARSNAP_BIN -c -f $NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) --one-file-system -C / $dir
 	if [ $? = 0 ] ; then
 	    if [ $QUIET != "1" ] ; then
 		echo "$NOW-$BK_TYPE-$(hostname -s)-$(echo $dir) backup done."
@@ -130,7 +132,7 @@ if [ $QUIET != "1" ] ; then
     echo "Verifying backups, please wait."
 fi
 
-archive_list=$(tarsnap --list-archives)
+archive_list=$($TARSNAP_BIN --list-archives)
 
 for dir in $(cat $PATHS) ; do
 	case "$archive_list" in
@@ -158,7 +160,7 @@ if [ $BK_TYPE = "HOURLY" ] ; then
 			 "$HOURLY_DELETE_TIME-$BK_TYPE"* ) 	
 					case "$backup" in   #this case added to make sure the script doesn't delete the backup it just took. Case: '-h x' and backup takes > x hours. 
 						*"$NOW"* ) echo "Skipped $backup" ;;
-						* )  tarsnap -d -f $backup
+						* )  $TARSNAP_BIN -d -f $backup
 							if [ $? = 0 ] ; then
 							    if [ $QUIET != "1" ] ; then
               							echo "$backup snapshot deleted."
@@ -179,7 +181,7 @@ if [ $BK_TYPE = "DAILY" ] ; then
                          "$DAILY_DELETE_TIME-$BK_TYPE"* )
 					 case "$backup" in
                                                 *"$NOW"* ) echo "Skipped $backup" ;;
-                                                * )  tarsnap -d -f $backup
+                                                * )  $TARSNAP_BIN -d -f $backup
                                        			 if [ $? = 0 ] ; then
 							     if [ $QUIET != "1" ] ; then 
                                                 		echo "$backup snapshot deleted."
@@ -199,7 +201,7 @@ if [ $BK_TYPE = "WEEKLY" ] ; then
                          "$WEEKLY_DELETE_TIME-$BK_TYPE"* ) 
 					 case "$backup" in
                                                 *"$NOW"* ) echo "Skipped $backup" ;;
-                                                * ) tarsnap -d -f $backup
+                                                * ) $TARSNAP_BIN -d -f $backup
                                         		if [ $? = 0 ] ; then
 							    if [ $QUIET != "1" ] ; then
                                                 		echo "$backup snapshot deleted."
@@ -219,7 +221,7 @@ if [ $BK_TYPE = "MONTHLY" ] ; then
                          "$MONTHLY_DELETE_TIME-$BK_TYPE"* ) 
 					 case "$backup" in
                                                 *"$NOW"* ) echo "Skipped $backup" ;;
-                                                * ) tarsnap -d -f $backup
+                                                * ) $TARSNAP_BIN -d -f $backup
                                         		if [ $? = 0 ] ; then
 							    if [ $QUIET != "1" ] ; then
                                                 		echo "$backup snapshot deleted."


### PR DESCRIPTION
Define a path to the tarsnap binary. Currently, when running via cron, tarsnap is not in $PATH and there is an error `Tarsnap-generations/tarsnap-generations.sh: line 118: tarsnap: command not found`
